### PR TITLE
Fix typo in VAGRANT_IMAGE for BoxCutter plain image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,7 +31,7 @@ VAGRANT_VM_FORWARD_IP    = '127.0.0.1'
 #VAGRANT_IMAGE = 'webdevops/ubuntu-docker'
 
 ## BoxCutter plain Ubuntu image
-VAGRANT_IMAGE = 'box-cutter/ubuntu1404-docker"'
+VAGRANT_IMAGE = 'box-cutter/ubuntu1404-docker'
 
 ###############################################################################
 ## --- Do not edit below ---


### PR DESCRIPTION
Hi Markus,

there was a small typo in the VAGRANT_FILE for the BoxCutter image. 

Cheers and thanks for the environment :-)
Marcus
