### PR TITLE
[TASK] Force Vagrant to use the private IP for SSH

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -316,6 +316,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     #################
     # Workarounds
     #################
+    config.ssh.host = configuration['VM']['network']['private']['address']
     if configuration['VM']['workaround']['useSshPasswordAuth']
         # Fallback ssh connection (https://github.com/mitchellh/vagrant/issues/5186)
         # -> Authentication issues? Workaround:


### PR DESCRIPTION
Since I had problems to get into my Vagrant machine with `vagrant ssh` and also had problems with `vagrant provision` it may be a good idea to add the private IP address to the Vagrant SSH configuration.