### PR TITLE
#111: Add support for setting up a custom timezone when provisioning the VM

### DIFF
--- a/provision/ansible/roles/common/handlers/main.yml
+++ b/provision/ansible/roles/common/handlers/main.yml
@@ -5,3 +5,8 @@
 
 - name: Update grub
   command: 'update-grub'
+
+- name: Restart services for timezone
+  command: 'service {{ item }} restart'
+  with_items:
+    - cron

--- a/provision/ansible/roles/common/tasks/main.yml
+++ b/provision/ansible/roles/common/tasks/main.yml
@@ -25,3 +25,9 @@
   include: locale.yml
   tags:
     - bootstrap
+
+- name: Setup timezone settings
+  include: timezone.yml
+  when: VM.timezone is defined
+  tags:
+    - bootstrap

--- a/provision/ansible/roles/common/tasks/timezone.yml
+++ b/provision/ansible/roles/common/tasks/timezone.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Change timezone
+  copy:
+    content: '{{ VM.timezone }}'
+    dest:    '/etc/timezone'
+    owner:   root
+    group:   root
+    mode:    0644
+    backup:  yes
+
+- name: Update timezone
+  command: '{{ item }}'
+  with_items:
+    # https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1554806
+    - rm -f /etc/localtime
+    - dpkg-reconfigure --frontend noninteractive tzdata
+  notify:
+    - Restart services for timezone

--- a/vm.yml
+++ b/vm.yml
@@ -57,6 +57,9 @@ VM:
   #   video memory (currently vbox only)
   vram:   100
 
+  # TimeZone (check tselect(1) for possible values)
+  #timezone: 'Etc/UTC'
+
   # ---------------------------------------------
   # Data image (additonal partition) settings
   #


### PR DESCRIPTION
Added new Ansible tasks inside the common role to change the timezone in the Ubuntu image when the _VM.timezone_ parameter is defined in `vm.yaml`, as requested in #111 .

Note: includes a workaround for [bug 1554806](https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1554806) in Ubuntu 16.10.